### PR TITLE
update ChainHelper to support both Bedrock and Ecotone

### DIFF
--- a/contracts/src/interfaces/IOPGasPriceOracle.sol
+++ b/contracts/src/interfaces/IOPGasPriceOracle.sol
@@ -7,10 +7,22 @@ interface IOPGasPriceOracle {
     /// @param _data Unsigned fully RLP-encoded transaction to get the L1 fee for.
     /// @return L1 fee that should be paid for the tx
     function getL1Fee(bytes memory _data) external view returns (uint256);
-    /// @notice Retrieves the current fee scalar.
-    /// @return Current fee scalar.
-    function scalar() external view returns (uint256);
     /// @notice Retrieves the latest known L1 base fee.
     /// @return Latest known L1 base fee.
     function l1BaseFee() external view returns (uint256);
+    /// @notice Retrieves the current blob base fee.
+    /// @return Current blob base fee.
+    function blobBaseFee() external view returns (uint256);
+    /// @notice Retrieves the current base fee scalar.
+    /// @return Current base fee scalar.
+    function baseFeeScalar() external view returns (uint32);
+    /// @notice Retrieves the current blob base fee scalar.
+    /// @return Current blob base fee scalar.
+    function blobBaseFeeScalar() external view returns (uint32);
+    /// @notice Indicates whether the network has gone through the Ecotone upgrade.
+    /// @return True if the network has gone through the Ecotone upgrade, false otherwise.
+    function isEcotone() external view returns (bool);
+    /// @notice Retrieves the current fee scalar. This is deprecated and will be removed in future.
+    /// @return Current fee scalar.
+    function scalar() external view returns (uint256);
 }

--- a/contracts/src/libraries/ChainHelper.sol
+++ b/contracts/src/libraries/ChainHelper.sol
@@ -6,27 +6,33 @@ import {IOPGasPriceOracle} from "../interfaces/IOPGasPriceOracle.sol";
 library ChainHelper {
     address public constant OP_GAS_PRICE_ORACLE_ADDR = address(0x420000000000000000000000000000000000000F);
     uint256 public constant OP_MAINNET_CHAIN_ID = 10;
-    uint256 public constant OP_GOERLI_TESTNET_CHAIN_ID = 420;
+    uint256 public constant OP_SEPOLIA_TESTNET_CHAIN_ID = 11155420;
     uint256 public constant OP_DEVNET_L1_CHAIN_ID = 900;
     uint256 public constant OP_DEVNET_L2_CHAIN_ID = 901;
     uint256 public constant BASE_MAINNET_CHAIN_ID = 8453;
-    uint256 public constant BASE_GOERLI_TESTNET_CHAIN_ID = 84531;
+    uint256 public constant BASE_SEPOLIA_TESTNET_CHAIN_ID = 84532;
     uint256 public constant REDSTONE_HOLESKY_TESTNET_CHAIN_ID = 17001;
+    uint256 public constant LOOT_MAINNET_CHAIN_ID = 5151706;
+    uint256 public constant LOOT_GOERLI_TESTNET_CHAIN_ID = 9088912;
 
-    uint32 public constant OP_BASIC_FULFILLMENT_L1_GAS_USED = 5016;
-    uint32 public constant OP_FULFILLMENT_GAS_PER_PARTICIPANT = 652;
-    uint256 public constant OP_DIVISOR_DECIMALS = 6;
+    uint32 public constant BASIC_FULFILLMENT_L1_GAS_USED = 5016;
+    uint32 public constant FULFILLMENT_GAS_PER_PARTICIPANT = 652;
+    uint256 public constant DECIMALS = 6;
 
     function getBlockTime() public view returns (uint256) {
         uint256 chainId = block.chainid;
         if (
-            chainId == OP_MAINNET_CHAIN_ID || chainId == OP_GOERLI_TESTNET_CHAIN_ID || chainId == OP_DEVNET_L2_CHAIN_ID
-                || chainId == BASE_MAINNET_CHAIN_ID || chainId == BASE_GOERLI_TESTNET_CHAIN_ID
+            chainId == OP_MAINNET_CHAIN_ID || chainId == OP_SEPOLIA_TESTNET_CHAIN_ID || chainId == OP_DEVNET_L2_CHAIN_ID
+                || chainId == BASE_MAINNET_CHAIN_ID || chainId == BASE_SEPOLIA_TESTNET_CHAIN_ID
                 || chainId == REDSTONE_HOLESKY_TESTNET_CHAIN_ID
         ) {
             return 2;
         } else if (chainId == OP_DEVNET_L1_CHAIN_ID) {
             return 3;
+        } else if (chainId == LOOT_MAINNET_CHAIN_ID) {
+            return 5;
+        } else if (chainId == LOOT_GOERLI_TESTNET_CHAIN_ID) {
+            return 200;
         }
         return 12;
     }
@@ -34,8 +40,8 @@ library ChainHelper {
     function getCurrentTxL1GasFees() public view returns (uint256) {
         uint256 chainId = block.chainid;
         if (
-            chainId == OP_MAINNET_CHAIN_ID || chainId == OP_GOERLI_TESTNET_CHAIN_ID || chainId == OP_DEVNET_L2_CHAIN_ID
-                || chainId == BASE_MAINNET_CHAIN_ID || chainId == BASE_GOERLI_TESTNET_CHAIN_ID
+            chainId == OP_MAINNET_CHAIN_ID || chainId == OP_SEPOLIA_TESTNET_CHAIN_ID || chainId == OP_DEVNET_L2_CHAIN_ID
+                || chainId == BASE_MAINNET_CHAIN_ID || chainId == BASE_SEPOLIA_TESTNET_CHAIN_ID
         ) {
             return IOPGasPriceOracle(OP_GAS_PRICE_ORACLE_ADDR).getL1Fee(msg.data);
         }
@@ -45,13 +51,24 @@ library ChainHelper {
     function getTxL1GasFees(uint256 l1GasUsed) public view returns (uint256) {
         uint256 chainId = block.chainid;
         if (
-            chainId == OP_MAINNET_CHAIN_ID || chainId == OP_GOERLI_TESTNET_CHAIN_ID || chainId == OP_DEVNET_L2_CHAIN_ID
-                || chainId == BASE_MAINNET_CHAIN_ID || chainId == BASE_GOERLI_TESTNET_CHAIN_ID
+            chainId == OP_MAINNET_CHAIN_ID || chainId == OP_SEPOLIA_TESTNET_CHAIN_ID || chainId == OP_DEVNET_L2_CHAIN_ID
+                || chainId == BASE_MAINNET_CHAIN_ID || chainId == BASE_SEPOLIA_TESTNET_CHAIN_ID
         ) {
-            uint256 l1Fee = l1GasUsed * IOPGasPriceOracle(OP_GAS_PRICE_ORACLE_ADDR).l1BaseFee();
-            uint256 divisor = 10 ** OP_DIVISOR_DECIMALS;
-            uint256 unscaled = l1Fee * IOPGasPriceOracle(OP_GAS_PRICE_ORACLE_ADDR).scalar();
-            return unscaled / divisor;
+            try IOPGasPriceOracle(OP_GAS_PRICE_ORACLE_ADDR).isEcotone() returns (bool isEcotone) {
+                if (isEcotone) {
+                    uint256 scaledBaseFee = IOPGasPriceOracle(OP_GAS_PRICE_ORACLE_ADDR).baseFeeScalar() * 16
+                        * IOPGasPriceOracle(OP_GAS_PRICE_ORACLE_ADDR).l1BaseFee();
+                    uint256 scaledBlobBaseFee = IOPGasPriceOracle(OP_GAS_PRICE_ORACLE_ADDR).blobBaseFeeScalar()
+                        * IOPGasPriceOracle(OP_GAS_PRICE_ORACLE_ADDR).blobBaseFee();
+                    uint256 fee = l1GasUsed * (scaledBaseFee + scaledBlobBaseFee);
+                    return fee / (16 * 10 ** DECIMALS);
+                }
+            } catch {
+                uint256 l1Fee = l1GasUsed * IOPGasPriceOracle(OP_GAS_PRICE_ORACLE_ADDR).l1BaseFee();
+                uint256 divisor = 10 ** DECIMALS;
+                uint256 unscaled = l1Fee * IOPGasPriceOracle(OP_GAS_PRICE_ORACLE_ADDR).scalar();
+                return unscaled / divisor;
+            }
         }
         return 0;
     }
@@ -59,10 +76,10 @@ library ChainHelper {
     function getFulfillmentTxL1GasUsed(uint32 groupSize) public view returns (uint256) {
         uint256 chainId = block.chainid;
         if (
-            chainId == OP_MAINNET_CHAIN_ID || chainId == OP_GOERLI_TESTNET_CHAIN_ID || chainId == OP_DEVNET_L2_CHAIN_ID
-                || chainId == BASE_MAINNET_CHAIN_ID || chainId == BASE_GOERLI_TESTNET_CHAIN_ID
+            chainId == OP_MAINNET_CHAIN_ID || chainId == OP_SEPOLIA_TESTNET_CHAIN_ID || chainId == OP_DEVNET_L2_CHAIN_ID
+                || chainId == BASE_MAINNET_CHAIN_ID || chainId == BASE_SEPOLIA_TESTNET_CHAIN_ID
         ) {
-            return OP_BASIC_FULFILLMENT_L1_GAS_USED + groupSize * OP_FULFILLMENT_GAS_PER_PARTICIPANT;
+            return BASIC_FULFILLMENT_L1_GAS_USED + groupSize * FULFILLMENT_GAS_PER_PARTICIPANT;
         }
         return 0;
     }


### PR DESCRIPTION
- update ChainHelper to support both Bedrock and Ecotone
- deprecate op goerli and base goerli
- prepare for coming loot chain deployment