### PR TITLE
Node client Bugfixes

### DIFF
--- a/docker/node-client/entrypoint.sh
+++ b/docker/node-client/entrypoint.sh
@@ -3,8 +3,17 @@
 echo "Starting supervisord job with the following command:"
 grep "command" /etc/supervisor/conf.d/supervisord.conf
 
+# Run prep-cloudwatch-config.sh
 echo "running prep-cloudwatch-config.sh"
 /app/prep-cloudwatch-config.sh
+
+# Check for existing log file, if it exists, archive it with the current date
+if [ -f /app/log/node.log ]; then
+  echo "Existing node.log found"
+  archived_log_name="/app/log/node.log.$(date +%Y-%m-%d-%H-%M-%S)"
+  mv /app/log/node.log "$archived_log_name"
+  echo "renamed node.log to $archived_log_name"
+fi
 
 # Run supervisord
 /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf

--- a/docker/node-client/prep-cloudwatch-config.sh
+++ b/docker/node-client/prep-cloudwatch-config.sh
@@ -5,6 +5,7 @@
 ######################################
 echo "########################################"
 # Run node-config-checker to compute wallet address from private key in config file
+cd /app # Change to the app directory so that node-config-checker can find keystore
 address=$(node-config-checker -c /app/config.yml)
 echo "Computed wallet address: $address from config file."
 


### PR DESCRIPTION
Fixed two bugs in node-client:
- entrypoint.sh now archives existing node.log to avoid uploading duplicate logs to CW.
- prep-cloudwatch-config.sh modified to ensure node-config-checker can find keystore files.